### PR TITLE
[example dependency error] sentry core should not depend on plugins

### DIFF
--- a/src/tach.toml
+++ b/src/tach.toml
@@ -27,7 +27,6 @@ depends_on = [
     { path = "bitfield" },
     { path = "django_picklefield" },
     { path = "flagpole" },
-    { path = "sentry_plugins", deprecated = true },
     { path = "social_auth" },
     { path = "sudo" },
 ]

--- a/src/tach.toml
+++ b/src/tach.toml
@@ -26,7 +26,7 @@ path = "sentry"
 depends_on = [
     { path = "bitfield" },
     { path = "django_picklefield" },
-    { path = "flagpole" },
+#    { path = "flagpole" },
     { path = "sentry_plugins" },
     { path = "social_auth" },
     { path = "sudo" },
@@ -51,7 +51,7 @@ depends_on = []
 [[interfaces]]
 expose = [
     ".*utils.*",
-    ".*integrations.*",
+#    ".*integrations.*",
     "utils.*"
 ]
 


### PR DESCRIPTION
Update tach config to remove `sentry_plugins` from `sentry`'s dependency list.